### PR TITLE
docs: align README with current live frontend

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,39 +1,87 @@
-### 今日热榜 (Today's Hot Rankings)
-通过爬虫采集数据，并进行可视化展示 (Data collection through web crawling and visualization display)
+# 今日热榜 (Today's Hot Rankings)
 
-爬虫项目(spider project): https://github.com/datehoer/hotToday
+通过爬虫采集数据，并进行可视化展示。  
+Collect hot-ranking data from multiple sources and present it through a web UI.
 
-demo: [~~原网站~~](https://hotrank.datehoer.com/) => https://www.hotday.uk/
+- Spider project: <https://github.com/datehoer/hotToday>
+- Website: <https://www.hotday.uk/>
+- Legacy site: ~~https://hotrank.datehoer.com/~~
 
-前后端项目 (Frontend and Backend Project)：
+## Project structure
 
-- 前端 (Frontend): vue2 + element-ui + [iconpark图标库](https://iconpark.oceanengine.com/official)
-- 后端 (Backend): python + fastapi
+This repository currently contains:
 
-后端部署建议(Backend Deployment Recommendations)：
+- **Backend**: Python + FastAPI
+- **Frontend (legacy)**: `ui/` — Vue 2 + Element UI + IconPark
+- **Frontend (current/live)**: `vue-ui/` — Vue 3 + Vite + TypeScript + Tailwind CSS + Heroicons
 
-docker编译镜像后使用下方命令启动docker容器，之后更新代码只需要重启容器即可(在不添加新的文件/库的情况下)
+> As of the current online deployment, **`https://www.hotday.uk/` is serving the `vue-ui/` frontend**.  
+> The live page loads Vite-built assets such as `/assets/index-*.js` and `/assets/index-*.css`, and its DOM structure/styles match `vue-ui/src/App.vue`.
 
-After building the Docker image, use the command below to start the Docker container. Afterward, updating the code only requires restarting the container (as long as you are not adding new files or libraries).
+## Backend
 
-2025.3.3 更新：
-- 修改了数据库改为了postgresql，原本的mongodb占用内存太大进行了替换
-- 增加了整体的速率限制
+Backend stack:
 
+- FastAPI
+- Redis
+- PostgreSQL
 
-~~~bash
-docker run -itd --name hotrank -v /var/www/hotday.uk/feed:/app/rss_feed.xml -v /var/www/hotday.uk/feed_with_ai:/app/rss_feed_today_top_news.xml -v /opt/hot-rank-web/app.py:/app/app.py -v /opt/hot-rank-web/parse_detail.py:/app/parse_detail.py -v /opt/hot-rank-web/common.py:/app/common.py -v /opt/hot-rank-web/config.py:/app/config.py -p 127.0.0.1:7545:7545 hotrank:v0.1
-~~~
-前端部署建议(Frontend Deployment Recommendations)：
-npm build后将文件复制到nginx文件夹即可
-After running npm build, copy the resulting files to the Nginx directory.
+Recent backend changes already reflected in the repo:
+
+- **2025-03-03**
+  - switched storage from MongoDB to PostgreSQL to reduce memory usage
+  - added global rate limiting
+
+### Backend deployment
+
+After building the Docker image, you can run the backend container like this:
+
+```bash
+docker run -itd --name hotrank \
+  -v /var/www/hotday.uk/feed:/app/rss_feed.xml \
+  -v /var/www/hotday.uk/feed_with_ai:/app/rss_feed_today_top_news.xml \
+  -v /opt/hot-rank-web/app.py:/app/app.py \
+  -v /opt/hot-rank-web/parse_detail.py:/app/parse_detail.py \
+  -v /opt/hot-rank-web/common.py:/app/common.py \
+  -v /opt/hot-rank-web/config.py:/app/config.py \
+  -p 127.0.0.1:7545:7545 \
+  hotrank:v0.1
+```
+
+If you are only updating code (without adding new dependencies/files into the image), restarting the container is usually enough.
+
+## Frontend
+
+### Current live frontend: `vue-ui/`
+
+Recommended commands:
+
+```bash
+cd vue-ui
+pnpm install
+pnpm run dev
+pnpm run build
+```
+
+After `pnpm run build`, deploy the generated static files from `vue-ui/dist/` to Nginx (or your static file host).
+
+### Legacy frontend: `ui/`
+
+The old frontend is still kept in the repository for compatibility/reference:
+
+```bash
+cd ui
+pnpm install
+pnpm run serve
+pnpm run build
+```
+
+If you are making changes intended for the currently deployed site, prefer working in **`vue-ui/`**.
+
+## Screenshots
 
 ![效果图1](https://oss.datehoer.com/blog/imgs/2024120523075359-20241205230752.png)
-
 ![效果图2](https://oss.datehoer.com/blog/imgs/2024120523082101-20241205230820.png)
-
 ![效果图3](https://oss.datehoer.com/blog/imgs/2024120523084962-20241205230849.png)
-
 ![效果图4](https://oss.datehoer.com/blog/imgs/2024120523090999-20241205230909.png)
-
 ![效果图5](https://oss.datehoer.com/blog/imgs/2024120523185650-20241205231856.png)

--- a/vue-ui/README.md
+++ b/vue-ui/README.md
@@ -1,5 +1,49 @@
-node = 22.17.1
+# vue-ui
 
+Current frontend for **https://www.hotday.uk/**.
+
+## Stack
+
+- Vue 3
+- Vite
+- TypeScript
+- Tailwind CSS
+- Vue Router
+- vue-i18n
+
+## Requirements
+
+- Node.js 22.x
+- pnpm
+
+## Install
+
+```bash
 pnpm install
+```
 
+## Development
+
+```bash
 pnpm run dev
+```
+
+## Build
+
+```bash
+pnpm run build
+```
+
+Build output will be generated in `dist/`.
+
+## Preview build locally
+
+```bash
+pnpm run preview
+```
+
+## Lint
+
+```bash
+pnpm run lint
+```


### PR DESCRIPTION
$## Summary\n- update the root README to reflect the current project structure\n- document that the live site is serving `vue-ui/` instead of the legacy `ui/` frontend\n- expand `vue-ui/README.md` with install/dev/build/preview/lint instructions\n\n## Why\nThe repository README still described the frontend as Vue 2 + Element UI, but the live site now loads Vite-built assets (`/assets/index-*.js` and `/assets/index-*.css`) and matches the Vue 3 app under `vue-ui/`.\n\n## Verification\n- visited https://www.hotday.uk/\n- confirmed the live page loads Vite bundle assets\n- confirmed the live DOM/classes match `vue-ui/src/App.vue`\n